### PR TITLE
PR for #56 - Updated NuGet packages

### DIFF
--- a/XPlat.ApplicationModel/XPlat.ApplicationModel.csproj
+++ b/XPlat.ApplicationModel/XPlat.ApplicationModel.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/XPlat.Core/XPlat.Core.csproj
+++ b/XPlat.Core/XPlat.Core.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/XPlat.Device.Profile/XPlat.Device.Profile.csproj
+++ b/XPlat.Device.Profile/XPlat.Device.Profile.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/XPlat.Devices.Display/XPlat.Device.Display.csproj
+++ b/XPlat.Devices.Display/XPlat.Device.Display.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">

--- a/XPlat.Devices.Geolocation/XPlat.Device.Geolocation.csproj
+++ b/XPlat.Devices.Geolocation/XPlat.Device.Geolocation.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
     <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 

--- a/XPlat.Devices.Launcher/XPlat.Device.Launcher.csproj
+++ b/XPlat.Devices.Launcher/XPlat.Device.Launcher.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">
-    <PackageReference Include="Xamarin.Android.Support.v4" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/XPlat.Devices.Launcher/XPlat.Device.Launcher.csproj
+++ b/XPlat.Devices.Launcher/XPlat.Device.Launcher.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">

--- a/XPlat.Devices.Power/XPlat.Device.Power.csproj
+++ b/XPlat.Devices.Power/XPlat.Device.Power.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">

--- a/XPlat.Media.Capture/XPlat.Media.Capture.csproj
+++ b/XPlat.Media.Capture/XPlat.Media.Capture.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">
-    <PackageReference Include="Xamarin.Android.Support.v4" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" />
     <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 

--- a/XPlat.Media.Capture/XPlat.Media.Capture.csproj
+++ b/XPlat.Media.Capture/XPlat.Media.Capture.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">

--- a/XPlat.Samples.Android/XPlat.Samples.Android.csproj
+++ b/XPlat.Samples.Android/XPlat.Samples.Android.csproj
@@ -145,15 +145,15 @@
     <PackageReference Include="Xamarin.Android.Support.Constraint.Layout">
       <Version>1.1.2</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Fragment">
-      <Version>27.0.2.1</Version>
+      <Version>28.0.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v4">
-      <Version>27.0.2.1</Version>
+      <Version>28.0.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-      <Version>27.0.2.1</Version>
+      <Version>28.0.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/XPlat.Samples.Android/XPlat.Samples.Android.csproj
+++ b/XPlat.Samples.Android/XPlat.Samples.Android.csproj
@@ -140,7 +140,7 @@
       <Version>5.4.1.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>11.0.2</Version>
+      <Version>12.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Constraint.Layout">
       <Version>1.1.2</Version>

--- a/XPlat.Samples.Android/XPlat.Samples.Android.csproj
+++ b/XPlat.Samples.Android/XPlat.Samples.Android.csproj
@@ -107,34 +107,34 @@
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="MADE.App">
-      <Version>0.1.18196.1</Version>
+      <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MADE.App.Design">
-      <Version>0.1.18196.1</Version>
+      <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MADE.App.Diagnostics">
-      <Version>0.1.18196.1</Version>
+      <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MADE.App.Mvvm">
-      <Version>0.1.18196.1</Version>
+      <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MADE.App.Networking">
-      <Version>0.1.18196.1</Version>
+      <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MADE.App.Views">
-      <Version>0.1.18196.1</Version>
+      <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MADE.App.Views.Controls.HeaderedTextBlock">
-      <Version>0.1.18196.1</Version>
+      <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MADE.App.Views.Dialogs">
-      <Version>0.1.18196.1</Version>
+      <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MADE.App.Views.Navigation">
-      <Version>0.1.18196.1</Version>
+      <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MADE.App.Views.Navigation.MvvmLight">
-      <Version>0.1.18196.1</Version>
+      <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MvvmLightLibs">
       <Version>5.4.1</Version>

--- a/XPlat.Samples.Android/XPlat.Samples.Android.csproj
+++ b/XPlat.Samples.Android/XPlat.Samples.Android.csproj
@@ -104,7 +104,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator">
-      <Version>2.0.3</Version>
+      <Version>2.0.4</Version>
     </PackageReference>
     <PackageReference Include="MADE.App">
       <Version>0.2.19058.1</Version>

--- a/XPlat.Samples.Android/XPlat.Samples.Android.csproj
+++ b/XPlat.Samples.Android/XPlat.Samples.Android.csproj
@@ -137,7 +137,7 @@
       <Version>0.2.19058.1</Version>
     </PackageReference>
     <PackageReference Include="MvvmLightLibs">
-      <Version>5.4.1</Version>
+      <Version>5.4.1.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>11.0.2</Version>

--- a/XPlat.Storage.Pickers/XPlat.Storage.Pickers.csproj
+++ b/XPlat.Storage.Pickers/XPlat.Storage.Pickers.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">

--- a/XPlat.Storage/XPlat.Storage.csproj
+++ b/XPlat.Storage/XPlat.Storage.csproj
@@ -35,12 +35,12 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'xamarin.ios10' ">
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 

--- a/XPlat.Storage/XPlat.Storage.csproj
+++ b/XPlat.Storage/XPlat.Storage.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">

--- a/XPlat.UI.Core/XPlat.UI.Core.csproj
+++ b/XPlat.UI.Core/XPlat.UI.Core.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/XPlat.UI.Popups/XPlat.UI.Popups.csproj
+++ b/XPlat.UI.Popups/XPlat.UI.Popups.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/XPlat.UI/XPlat.UI.csproj
+++ b/XPlat.UI/XPlat.UI.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.7" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/XPlat.UnitTests.Windows/XPlat.UnitTests.Windows.csproj
+++ b/XPlat.UnitTests.Windows/XPlat.UnitTests.Windows.csproj
@@ -134,10 +134,10 @@
       <Version>6.1.9</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>1.1.11</Version>
+      <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>1.1.11</Version>
+      <Version>1.4.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/XPlat.UnitTests.Windows/XPlat.UnitTests.Windows.csproj
+++ b/XPlat.UnitTests.Windows/XPlat.UnitTests.Windows.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>XPlat.UnitTests.Windows</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -131,7 +131,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.7</Version>
+      <Version>6.1.9</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
       <Version>1.1.11</Version>

--- a/XPlat.UnitTests/XPlat.UnitTests.csproj
+++ b/XPlat.UnitTests/XPlat.UnitTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/XPlat.sln
+++ b/XPlat.sln
@@ -49,7 +49,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.UI.Popups", "XPlat.UI
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XPlat.Samples.iOS", "XPlat.Samples.iOS\XPlat.Samples.iOS.csproj", "{101E3060-8799-4119-8A7A-4F86A01C0C84}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XPlat.ApplicationModel", "XPlat.ApplicationModel\XPlat.ApplicationModel.csproj", "{08E1FD7A-DB1F-416B-AFF8-1ACEC7525419}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.ApplicationModel", "XPlat.ApplicationModel\XPlat.ApplicationModel.csproj", "{08E1FD7A-DB1F-416B-AFF8-1ACEC7525419}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This PR includes a change to the XPlat referenced NuGet packages to update them to the latest supported versions. 

Updated packages including:
- Microsoft.NETCore.UniversalWindowsPlatform to 6.1.9
- MADE to 0.2.19058.1
- CommonServiceLocator to 2.0.4
- MvvmLightLibs to 5.4.1.1
- Newtonsoft.Json to 12.0.1
- MS Test to 1.4.0
- Xamarin.Support to 28.0.0.1