### PR TITLE
Fixed issue with Android file picker not supporting cloud providers

### DIFF
--- a/XPlat.Devices.Display/XPlat.Device.Display.csproj
+++ b/XPlat.Devices.Display/XPlat.Device.Display.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">
+  <ItemGroup>
     <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 

--- a/XPlat.Devices.Geolocation/XPlat.Device.Geolocation.csproj
+++ b/XPlat.Devices.Geolocation/XPlat.Device.Geolocation.csproj
@@ -32,15 +32,11 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
-    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'xamarin.ios10' ">
-    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\XPlat.Foundation\XPlat.Foundation.csproj" />
+    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/XPlat.Devices.Power/XPlat.Device.Power.csproj
+++ b/XPlat.Devices.Power/XPlat.Device.Power.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">
+  <ItemGroup>
     <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 

--- a/XPlat.Media.Capture/XPlat.Media.Capture.csproj
+++ b/XPlat.Media.Capture/XPlat.Media.Capture.csproj
@@ -37,10 +37,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" />
-    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
     <ProjectReference Include="..\XPlat.Storage\XPlat.Storage.csproj" />
   </ItemGroup>
 

--- a/XPlat.Samples.Android/AndroidLocator.cs
+++ b/XPlat.Samples.Android/AndroidLocator.cs
@@ -28,6 +28,7 @@ namespace XPlat.Samples.Android
 
             SimpleIoc.Default.Register<MainFragmentViewModel>();
             SimpleIoc.Default.Register<CameraCaptureFragmentViewModel>();
+            SimpleIoc.Default.Register<FileCaptureFragmentViewModel>();
         }
     }
 }

--- a/XPlat.Samples.Android/Fragments/FileCaptureFragment.cs
+++ b/XPlat.Samples.Android/Fragments/FileCaptureFragment.cs
@@ -1,0 +1,46 @@
+﻿namespace XPlat.Samples.Android.Fragments
+{
+    using CommonServiceLocator;
+
+    using global::Android.Widget;
+
+    using MADE.App.Views.Navigation.Pages;
+
+    using XPlat.Samples.Android.ViewModels;
+
+    public class FileCaptureFragment : MvvmPage
+    {
+        private Button openFileButton;
+
+        public FileCaptureFragment()
+        {
+            this.DataContext = ServiceLocator.Current.GetInstance<FileCaptureFragmentViewModel>();
+        }
+
+        public override int LayoutId => Resource.Layout.FileCaptureFragment;
+
+        protected FileCaptureFragmentViewModel ViewModel => this.DataContext as FileCaptureFragmentViewModel;
+
+        public override void OnResume()
+        {
+            if (this.openFileButton != null)
+            {
+                this.openFileButton.Click -= this.OnOpenFileClick;
+            }
+
+            base.OnResume();
+
+            this.openFileButton = this.GetChildView<Button>(Resource.Id.capture_file);
+
+            if (this.openFileButton != null)
+            {
+                this.openFileButton.Click += this.OnOpenFileClick;
+            }
+        }
+
+        private async void OnOpenFileClick(object sender, System.EventArgs e)
+        {
+            object storageFile = await this.ViewModel.CaptureFileAsync(this.Context);
+        }
+    }
+}

--- a/XPlat.Samples.Android/Fragments/MainFragment.cs
+++ b/XPlat.Samples.Android/Fragments/MainFragment.cs
@@ -23,6 +23,8 @@
 
         private Button navigateToLauncherButton;
 
+        private Button navigateToOpenFileButton;
+
         private Package package;
 
         public MainFragment()
@@ -60,12 +62,18 @@
                 this.navigateToLauncherButton.Click -= this.OnNavigateToLauncherClick;
             }
 
+            if (this.navigateToOpenFileButton != null)
+            {
+                this.navigateToOpenFileButton.Click -= this.OnNavigateToOpenFileClick;
+            }
+
             base.OnResume();
 
             this.navigateToCameraCaptureButton = this.GetChildView<Button>(Resource.Id.navigate_to_camera_capture);
             this.navigateToDisplayRequestButton = this.GetChildView<Button>(Resource.Id.navigate_to_display_request);
             this.navigateToGeolocatorButton = this.GetChildView<Button>(Resource.Id.navigate_to_geolocator);
             this.navigateToLauncherButton = this.GetChildView<Button>(Resource.Id.navigate_to_launcher);
+            this.navigateToOpenFileButton = this.GetChildView<Button>(Resource.Id.navigate_to_open_file);
 
             if (this.navigateToCameraCaptureButton != null)
             {
@@ -87,6 +95,11 @@
                 this.navigateToLauncherButton.Click += this.OnNavigateToLauncherClick;
             }
 
+            if (this.navigateToOpenFileButton != null)
+            {
+                this.navigateToOpenFileButton.Click += this.OnNavigateToOpenFileClick;
+            }
+
             MessageDialog message = new MessageDialog("Hello, World", "Title")
                               {
                                   Context = this.Context, DefaultCommandIndex = 0, CancelCommandIndex = 1
@@ -96,6 +109,11 @@
             IUICommand result = await message.ShowAsync();
 
             Debug.WriteLine(result == null ? "Dismissed without choosing a result" : result.Label);
+        }
+
+        private void OnNavigateToOpenFileClick(object sender, EventArgs e)
+        {
+            this.ViewModel?.NavigateToSample(typeof(FileCaptureFragment), null);
         }
 
         private void OnNavigateToLauncherClick(object sender, EventArgs e)

--- a/XPlat.Samples.Android/Resources/Resource.Designer.cs
+++ b/XPlat.Samples.Android/Resources/Resource.Designer.cs
@@ -4488,20 +4488,20 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a0034
 			public const int FUNCTION = 2131361844;
 			
+			// aapt resource value: 0x7f0a00b1
+			public const int HeaderedTextBlock_ContentTextView = 2131361969;
+			
 			// aapt resource value: 0x7f0a00b0
-			public const int HeaderedTextBlock_ContentTextView = 2131361968;
+			public const int HeaderedTextBlock_HeaderTextView = 2131361968;
 			
 			// aapt resource value: 0x7f0a00af
-			public const int HeaderedTextBlock_HeaderTextView = 2131361967;
-			
-			// aapt resource value: 0x7f0a00ae
-			public const int HeaderedTextBlock_LayoutContainer = 2131361966;
+			public const int HeaderedTextBlock_LayoutContainer = 2131361967;
 			
 			// aapt resource value: 0x7f0a0035
 			public const int META = 2131361845;
 			
-			// aapt resource value: 0x7f0a00b2
-			public const int MainContent = 2131361970;
+			// aapt resource value: 0x7f0a00b3
+			public const int MainContent = 2131361971;
 			
 			// aapt resource value: 0x7f0a0036
 			public const int SHIFT = 2131361846;
@@ -4509,8 +4509,8 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a0037
 			public const int SYM = 2131361847;
 			
-			// aapt resource value: 0x7f0a00ba
-			public const int action0 = 2131361978;
+			// aapt resource value: 0x7f0a00bc
+			public const int action0 = 2131361980;
 			
 			// aapt resource value: 0x7f0a0089
 			public const int action_bar = 2131361929;
@@ -4533,17 +4533,17 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a0067
 			public const int action_bar_title = 2131361895;
 			
-			// aapt resource value: 0x7f0a00b7
-			public const int action_container = 2131361975;
+			// aapt resource value: 0x7f0a00b9
+			public const int action_container = 2131361977;
 			
 			// aapt resource value: 0x7f0a008a
 			public const int action_context_bar = 2131361930;
 			
-			// aapt resource value: 0x7f0a00be
-			public const int action_divider = 2131361982;
+			// aapt resource value: 0x7f0a00c0
+			public const int action_divider = 2131361984;
 			
-			// aapt resource value: 0x7f0a00b8
-			public const int action_image = 2131361976;
+			// aapt resource value: 0x7f0a00ba
+			public const int action_image = 2131361978;
 			
 			// aapt resource value: 0x7f0a0003
 			public const int action_menu_divider = 2131361795;
@@ -4560,11 +4560,11 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a0069
 			public const int action_mode_close_button = 2131361897;
 			
-			// aapt resource value: 0x7f0a00b9
-			public const int action_text = 2131361977;
+			// aapt resource value: 0x7f0a00bb
+			public const int action_text = 2131361979;
 			
-			// aapt resource value: 0x7f0a00c7
-			public const int actions = 2131361991;
+			// aapt resource value: 0x7f0a00c9
+			public const int actions = 2131361993;
 			
 			// aapt resource value: 0x7f0a006a
 			public const int activity_chooser_view_content = 2131361898;
@@ -4602,8 +4602,11 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a0070
 			public const int buttonPanel = 2131361904;
 			
-			// aapt resource value: 0x7f0a00bb
-			public const int cancel_action = 2131361979;
+			// aapt resource value: 0x7f0a00bd
+			public const int cancel_action = 2131361981;
+			
+			// aapt resource value: 0x7f0a00aa
+			public const int capture_file = 2131361962;
 			
 			// aapt resource value: 0x7f0a0098
 			public const int capture_image = 2131361944;
@@ -4626,8 +4629,8 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a0080
 			public const int checkbox = 2131361920;
 			
-			// aapt resource value: 0x7f0a00c3
-			public const int chronometer = 2131361987;
+			// aapt resource value: 0x7f0a00c5
+			public const int chronometer = 2131361989;
 			
 			// aapt resource value: 0x7f0a004e
 			public const int clip_horizontal = 2131361870;
@@ -4647,8 +4650,8 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a009d
 			public const int coordinator = 2131361949;
 			
-			// aapt resource value: 0x7f0a00ad
-			public const int current_position = 2131361965;
+			// aapt resource value: 0x7f0a00ae
+			public const int current_position = 2131361966;
 			
 			// aapt resource value: 0x7f0a007a
 			public const int custom = 2131361914;
@@ -4692,8 +4695,8 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a0030
 			public const int end = 2131361840;
 			
-			// aapt resource value: 0x7f0a00c9
-			public const int end_padder = 2131361993;
+			// aapt resource value: 0x7f0a00cb
+			public const int end_padder = 2131361995;
 			
 			// aapt resource value: 0x7f0a003f
 			public const int enterAlways = 2131361855;
@@ -4740,8 +4743,8 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a006f
 			public const int icon = 2131361903;
 			
-			// aapt resource value: 0x7f0a00c8
-			public const int icon_group = 2131361992;
+			// aapt resource value: 0x7f0a00ca
+			public const int icon_group = 2131361994;
 			
 			// aapt resource value: 0x7f0a003a
 			public const int ifRoom = 2131361850;
@@ -4749,8 +4752,8 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a006c
 			public const int image = 2131361900;
 			
-			// aapt resource value: 0x7f0a00c4
-			public const int info = 2131361988;
+			// aapt resource value: 0x7f0a00c6
+			public const int info = 2131361990;
 			
 			// aapt resource value: 0x7f0a0057
 			public const int invisible = 2131361879;
@@ -4764,8 +4767,8 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a009b
 			public const int largeLabel = 2131361947;
 			
-			// aapt resource value: 0x7f0a00b1
-			public const int launch_uri = 2131361969;
+			// aapt resource value: 0x7f0a00b2
+			public const int launch_uri = 2131361970;
 			
 			// aapt resource value: 0x7f0a0049
 			public const int left = 2131361865;
@@ -4782,20 +4785,20 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a006e
 			public const int list_item = 2131361902;
 			
-			// aapt resource value: 0x7f0a00ab
-			public const int location_access_status = 2131361963;
-			
 			// aapt resource value: 0x7f0a00ac
-			public const int location_provider_status = 2131361964;
+			public const int location_access_status = 2131361964;
+			
+			// aapt resource value: 0x7f0a00ad
+			public const int location_provider_status = 2131361965;
+			
+			// aapt resource value: 0x7f0a00ce
+			public const int masked = 2131361998;
+			
+			// aapt resource value: 0x7f0a00bf
+			public const int media_actions = 2131361983;
 			
 			// aapt resource value: 0x7f0a00cc
-			public const int masked = 2131361996;
-			
-			// aapt resource value: 0x7f0a00bd
-			public const int media_actions = 2131361981;
-			
-			// aapt resource value: 0x7f0a00ca
-			public const int message = 2131361994;
+			public const int message = 2131361996;
 			
 			// aapt resource value: 0x7f0a0031
 			public const int middle = 2131361841;
@@ -4806,17 +4809,20 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a0028
 			public const int multiply = 2131361832;
 			
-			// aapt resource value: 0x7f0a00b3
-			public const int navigate_to_camera_capture = 2131361971;
-			
 			// aapt resource value: 0x7f0a00b4
-			public const int navigate_to_display_request = 2131361972;
+			public const int navigate_to_camera_capture = 2131361972;
 			
 			// aapt resource value: 0x7f0a00b5
-			public const int navigate_to_geolocator = 2131361973;
+			public const int navigate_to_display_request = 2131361973;
 			
 			// aapt resource value: 0x7f0a00b6
-			public const int navigate_to_launcher = 2131361974;
+			public const int navigate_to_geolocator = 2131361974;
+			
+			// aapt resource value: 0x7f0a00b7
+			public const int navigate_to_launcher = 2131361975;
+			
+			// aapt resource value: 0x7f0a00b8
+			public const int navigate_to_open_file = 2131361976;
 			
 			// aapt resource value: 0x7f0a00a2
 			public const int navigation_header_container = 2131361954;
@@ -4830,14 +4836,14 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a001e
 			public const int normal = 2131361822;
 			
-			// aapt resource value: 0x7f0a00c6
-			public const int notification_background = 2131361990;
+			// aapt resource value: 0x7f0a00c8
+			public const int notification_background = 2131361992;
 			
-			// aapt resource value: 0x7f0a00c0
-			public const int notification_main_column = 2131361984;
+			// aapt resource value: 0x7f0a00c2
+			public const int notification_main_column = 2131361986;
 			
-			// aapt resource value: 0x7f0a00bf
-			public const int notification_main_column_container = 2131361983;
+			// aapt resource value: 0x7f0a00c1
+			public const int notification_main_column_container = 2131361985;
 			
 			// aapt resource value: 0x7f0a005c
 			public const int packed = 2131361884;
@@ -4875,17 +4881,17 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a00a8
 			public const int request_display_lock = 2131361960;
 			
-			// aapt resource value: 0x7f0a00aa
-			public const int request_location_access = 2131361962;
+			// aapt resource value: 0x7f0a00ab
+			public const int request_location_access = 2131361963;
 			
 			// aapt resource value: 0x7f0a004a
 			public const int right = 2131361866;
 			
-			// aapt resource value: 0x7f0a00c5
-			public const int right_icon = 2131361989;
+			// aapt resource value: 0x7f0a00c7
+			public const int right_icon = 2131361991;
 			
-			// aapt resource value: 0x7f0a00c1
-			public const int right_side = 2131361985;
+			// aapt resource value: 0x7f0a00c3
+			public const int right_side = 2131361987;
 			
 			// aapt resource value: 0x7f0a000c
 			public const int save_image_matrix = 2131361804;
@@ -4998,8 +5004,8 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a004b
 			public const int start = 2131361867;
 			
-			// aapt resource value: 0x7f0a00bc
-			public const int status_bar_latest_event_content = 2131361980;
+			// aapt resource value: 0x7f0a00be
+			public const int status_bar_latest_event_content = 2131361982;
 			
 			// aapt resource value: 0x7f0a0083
 			public const int submenuarrow = 2131361923;
@@ -5034,8 +5040,8 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a0015
 			public const int textinput_error = 2131361813;
 			
-			// aapt resource value: 0x7f0a00c2
-			public const int time = 2131361986;
+			// aapt resource value: 0x7f0a00c4
+			public const int time = 2131361988;
 			
 			// aapt resource value: 0x7f0a001c
 			public const int title = 2131361820;
@@ -5082,8 +5088,8 @@ namespace XPlat.Samples.Android
 			// aapt resource value: 0x7f0a0016
 			public const int view_offset_helper = 2131361814;
 			
-			// aapt resource value: 0x7f0a00cb
-			public const int visible = 2131361995;
+			// aapt resource value: 0x7f0a00cd
+			public const int visible = 2131361997;
 			
 			// aapt resource value: 0x7f0a003c
 			public const int withText = 2131361852;
@@ -5277,79 +5283,82 @@ namespace XPlat.Samples.Android
 			public const int DisplayRequestFragment = 2130968617;
 			
 			// aapt resource value: 0x7f04002a
-			public const int GeolocatorFragment = 2130968618;
+			public const int FileCaptureFragment = 2130968618;
 			
 			// aapt resource value: 0x7f04002b
-			public const int HeaderedTextBlockLayout = 2130968619;
+			public const int GeolocatorFragment = 2130968619;
 			
 			// aapt resource value: 0x7f04002c
-			public const int LauncherFragment = 2130968620;
+			public const int HeaderedTextBlockLayout = 2130968620;
 			
 			// aapt resource value: 0x7f04002d
-			public const int Main = 2130968621;
+			public const int LauncherFragment = 2130968621;
 			
 			// aapt resource value: 0x7f04002e
-			public const int MainFragment = 2130968622;
+			public const int Main = 2130968622;
 			
 			// aapt resource value: 0x7f04002f
-			public const int notification_action = 2130968623;
+			public const int MainFragment = 2130968623;
 			
 			// aapt resource value: 0x7f040030
-			public const int notification_action_tombstone = 2130968624;
+			public const int notification_action = 2130968624;
 			
 			// aapt resource value: 0x7f040031
-			public const int notification_media_action = 2130968625;
+			public const int notification_action_tombstone = 2130968625;
 			
 			// aapt resource value: 0x7f040032
-			public const int notification_media_cancel_action = 2130968626;
+			public const int notification_media_action = 2130968626;
 			
 			// aapt resource value: 0x7f040033
-			public const int notification_template_big_media = 2130968627;
+			public const int notification_media_cancel_action = 2130968627;
 			
 			// aapt resource value: 0x7f040034
-			public const int notification_template_big_media_custom = 2130968628;
+			public const int notification_template_big_media = 2130968628;
 			
 			// aapt resource value: 0x7f040035
-			public const int notification_template_big_media_narrow = 2130968629;
+			public const int notification_template_big_media_custom = 2130968629;
 			
 			// aapt resource value: 0x7f040036
-			public const int notification_template_big_media_narrow_custom = 2130968630;
+			public const int notification_template_big_media_narrow = 2130968630;
 			
 			// aapt resource value: 0x7f040037
-			public const int notification_template_custom_big = 2130968631;
+			public const int notification_template_big_media_narrow_custom = 2130968631;
 			
 			// aapt resource value: 0x7f040038
-			public const int notification_template_icon_group = 2130968632;
+			public const int notification_template_custom_big = 2130968632;
 			
 			// aapt resource value: 0x7f040039
-			public const int notification_template_lines_media = 2130968633;
+			public const int notification_template_icon_group = 2130968633;
 			
 			// aapt resource value: 0x7f04003a
-			public const int notification_template_media = 2130968634;
+			public const int notification_template_lines_media = 2130968634;
 			
 			// aapt resource value: 0x7f04003b
-			public const int notification_template_media_custom = 2130968635;
+			public const int notification_template_media = 2130968635;
 			
 			// aapt resource value: 0x7f04003c
-			public const int notification_template_part_chronometer = 2130968636;
+			public const int notification_template_media_custom = 2130968636;
 			
 			// aapt resource value: 0x7f04003d
-			public const int notification_template_part_time = 2130968637;
+			public const int notification_template_part_chronometer = 2130968637;
 			
 			// aapt resource value: 0x7f04003e
-			public const int select_dialog_item_material = 2130968638;
+			public const int notification_template_part_time = 2130968638;
 			
 			// aapt resource value: 0x7f04003f
-			public const int select_dialog_multichoice_material = 2130968639;
+			public const int select_dialog_item_material = 2130968639;
 			
 			// aapt resource value: 0x7f040040
-			public const int select_dialog_singlechoice_material = 2130968640;
+			public const int select_dialog_multichoice_material = 2130968640;
 			
 			// aapt resource value: 0x7f040041
-			public const int support_simple_spinner_dropdown_item = 2130968641;
+			public const int select_dialog_singlechoice_material = 2130968641;
 			
 			// aapt resource value: 0x7f040042
-			public const int tooltip = 2130968642;
+			public const int support_simple_spinner_dropdown_item = 2130968642;
+			
+			// aapt resource value: 0x7f040043
+			public const int tooltip = 2130968643;
 			
 			static Layout()
 			{

--- a/XPlat.Samples.Android/Resources/layout/FileCaptureFragment.axml
+++ b/XPlat.Samples.Android/Resources/layout/FileCaptureFragment.axml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+		<Button 
+		    android:id="@+id/capture_file" 
+			android:layout_width="match_parent" 
+			android:layout_height="wrap_content"
+			android:text="Open File" />
+</LinearLayout>

--- a/XPlat.Samples.Android/Resources/layout/MainFragment.axml
+++ b/XPlat.Samples.Android/Resources/layout/MainFragment.axml
@@ -10,5 +10,6 @@
 	<Button android:id="@+id/navigate_to_display_request" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="DisplayRequest Sample" />
 	<Button android:id="@+id/navigate_to_geolocator" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Geolocator Sample" />
 	<Button android:id="@+id/navigate_to_launcher" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="Launcher Sample" />
+	<Button android:id="@+id/navigate_to_open_file" android:layout_width="match_parent" android:layout_height="wrap_content" android:text="File Picker Sample" />
 
 </LinearLayout>

--- a/XPlat.Samples.Android/ViewModels/FileCaptureFragmentViewModel.cs
+++ b/XPlat.Samples.Android/ViewModels/FileCaptureFragmentViewModel.cs
@@ -1,0 +1,63 @@
+﻿namespace XPlat.Samples.Android.ViewModels
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    using global::Android.Content;
+
+    using MADE.App.Views.Navigation.ViewModels;
+
+    using XPlat.Storage;
+    using XPlat.Storage.FileProperties;
+    using XPlat.Storage.Pickers;
+
+    public class FileCaptureFragmentViewModel : PageViewModel
+    {
+        private readonly List<string> fileTypes;
+
+        public FileCaptureFragmentViewModel()
+        {
+            this.fileTypes = new List<string>()
+                                 {
+                                     ".mp4",
+                                     ".wav",
+                                     ".wma",
+                                     ".mid",
+                                     ".mp3",
+                                     ".3gp",
+                                     ".avi",
+                                     ".flv",
+                                     ".mov",
+                                     ".mpg",
+                                     ".wmv",
+                                     ".jpg",
+                                     ".png",
+                                     ".gif",
+                                     ".bmp",
+                                     ".tif",
+                                     ".tiff",
+                                     ".txt",
+                                     ".doc",
+                                     ".docx",
+                                     ".pdf",
+                                     ".7z",
+                                     ".rar",
+                                     ".zip"
+                                 };
+        }
+
+        public async Task<object> CaptureFileAsync(Context context)
+        {
+            FileOpenPicker picker = new FileOpenPicker(context);
+
+            foreach (var fileType in this.fileTypes)
+            {
+                picker.FileTypeFilter.Add(fileType);
+            }
+
+            IStorageFile file = await picker.PickSingleFileAsync();
+            IBasicProperties properties = await file.GetBasicPropertiesAsync();
+            return file;
+        }
+    }
+}

--- a/XPlat.Samples.Android/XPlat.Samples.Android.csproj
+++ b/XPlat.Samples.Android/XPlat.Samples.Android.csproj
@@ -60,6 +60,7 @@
     <Compile Include="AndroidLocator.cs" />
     <Compile Include="Fragments\CameraCaptureFragment.cs" />
     <Compile Include="Fragments\DisplayRequestFragment.cs" />
+    <Compile Include="Fragments\FileCaptureFragment.cs" />
     <Compile Include="Fragments\GeolocatorFragment.cs" />
     <Compile Include="Fragments\LauncherFragment.cs" />
     <Compile Include="Fragments\MainFragment.cs" />
@@ -69,6 +70,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\NavigationService.cs" />
     <Compile Include="ViewModels\CameraCaptureFragmentViewModel.cs" />
+    <Compile Include="ViewModels\FileCaptureFragmentViewModel.cs" />
     <Compile Include="ViewModels\MainFragmentViewModel.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -239,6 +241,11 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\LauncherFragment.axml">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\layout\FileCaptureFragment.axml">
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>

--- a/XPlat.Storage.Pickers/FileOpenPicker.Android.cs
+++ b/XPlat.Storage.Pickers/FileOpenPicker.Android.cs
@@ -129,7 +129,7 @@ namespace XPlat.Storage.Pickers
 
             fileOpenPickerIntent.PutExtra(FileOpenPickerActivity.IntentType, "*/*");
             fileOpenPickerIntent.PutExtra(Intent.ExtraMimeTypes, mimeTypes.ToArray());
-            fileOpenPickerIntent.PutExtra(FileOpenPickerActivity.IntentAction, Intent.ActionGetContent);
+            fileOpenPickerIntent.PutExtra(FileOpenPickerActivity.IntentAction, Intent.ActionOpenDocument);
 
             if (allowMultiple)
             {

--- a/XPlat.Storage.Pickers/XPlat.Storage.Pickers.csproj
+++ b/XPlat.Storage.Pickers/XPlat.Storage.Pickers.csproj
@@ -34,12 +34,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">
-    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\XPlat.Foundation\XPlat.Foundation.csproj" />
+    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
     <ProjectReference Include="..\XPlat.Storage\XPlat.Storage.csproj" />
   </ItemGroup>
 

--- a/XPlat.Storage/XPlat.Storage.csproj
+++ b/XPlat.Storage/XPlat.Storage.csproj
@@ -36,16 +36,15 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'monoandroid81' ">
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'xamarin.ios10' ">
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\XPlat.Foundation\XPlat.Foundation.csproj" />
+    <ProjectReference Include="..\XPlat.Core\XPlat.Core.csproj" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/XPlat.UnitTests.Android/Resources/Resource.Designer.cs
+++ b/XPlat.UnitTests.Android/Resources/Resource.Designer.cs
@@ -53,33 +53,6 @@ namespace XPlat.UnitTests.Android
 		public partial class Attribute
 		{
 			
-			// aapt resource value: 0x7f010007
-			public const int font = 2130771975;
-			
-			// aapt resource value: 0x7f010000
-			public const int fontProviderAuthority = 2130771968;
-			
-			// aapt resource value: 0x7f010003
-			public const int fontProviderCerts = 2130771971;
-			
-			// aapt resource value: 0x7f010004
-			public const int fontProviderFetchStrategy = 2130771972;
-			
-			// aapt resource value: 0x7f010005
-			public const int fontProviderFetchTimeout = 2130771973;
-			
-			// aapt resource value: 0x7f010001
-			public const int fontProviderPackage = 2130771969;
-			
-			// aapt resource value: 0x7f010002
-			public const int fontProviderQuery = 2130771970;
-			
-			// aapt resource value: 0x7f010006
-			public const int fontStyle = 2130771974;
-			
-			// aapt resource value: 0x7f010008
-			public const int fontWeight = 2130771976;
-			
 			static Attribute()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
@@ -90,161 +63,11 @@ namespace XPlat.UnitTests.Android
 			}
 		}
 		
-		public partial class Boolean
-		{
-			
-			// aapt resource value: 0x7f050000
-			public const int abc_action_bar_embed_tabs = 2131034112;
-			
-			static Boolean()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Boolean()
-			{
-			}
-		}
-		
-		public partial class Color
-		{
-			
-			// aapt resource value: 0x7f070000
-			public const int notification_action_color_filter = 2131165184;
-			
-			// aapt resource value: 0x7f070001
-			public const int notification_icon_bg_color = 2131165185;
-			
-			// aapt resource value: 0x7f070002
-			public const int ripple_material_light = 2131165186;
-			
-			// aapt resource value: 0x7f070003
-			public const int secondary_text_default_material_light = 2131165187;
-			
-			static Color()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Color()
-			{
-			}
-		}
-		
-		public partial class Dimension
-		{
-			
-			// aapt resource value: 0x7f060004
-			public const int compat_button_inset_horizontal_material = 2131099652;
-			
-			// aapt resource value: 0x7f060005
-			public const int compat_button_inset_vertical_material = 2131099653;
-			
-			// aapt resource value: 0x7f060006
-			public const int compat_button_padding_horizontal_material = 2131099654;
-			
-			// aapt resource value: 0x7f060007
-			public const int compat_button_padding_vertical_material = 2131099655;
-			
-			// aapt resource value: 0x7f060008
-			public const int compat_control_corner_material = 2131099656;
-			
-			// aapt resource value: 0x7f060009
-			public const int notification_action_icon_size = 2131099657;
-			
-			// aapt resource value: 0x7f06000a
-			public const int notification_action_text_size = 2131099658;
-			
-			// aapt resource value: 0x7f06000b
-			public const int notification_big_circle_margin = 2131099659;
-			
-			// aapt resource value: 0x7f060001
-			public const int notification_content_margin_start = 2131099649;
-			
-			// aapt resource value: 0x7f06000c
-			public const int notification_large_icon_height = 2131099660;
-			
-			// aapt resource value: 0x7f06000d
-			public const int notification_large_icon_width = 2131099661;
-			
-			// aapt resource value: 0x7f060002
-			public const int notification_main_column_padding_top = 2131099650;
-			
-			// aapt resource value: 0x7f060003
-			public const int notification_media_narrow_margin = 2131099651;
-			
-			// aapt resource value: 0x7f06000e
-			public const int notification_right_icon_size = 2131099662;
-			
-			// aapt resource value: 0x7f060000
-			public const int notification_right_side_padding_top = 2131099648;
-			
-			// aapt resource value: 0x7f06000f
-			public const int notification_small_icon_background_padding = 2131099663;
-			
-			// aapt resource value: 0x7f060010
-			public const int notification_small_icon_size_as_large = 2131099664;
-			
-			// aapt resource value: 0x7f060011
-			public const int notification_subtext_size = 2131099665;
-			
-			// aapt resource value: 0x7f060012
-			public const int notification_top_pad = 2131099666;
-			
-			// aapt resource value: 0x7f060013
-			public const int notification_top_pad_large_text = 2131099667;
-			
-			static Dimension()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Dimension()
-			{
-			}
-		}
-		
 		public partial class Drawable
 		{
 			
 			// aapt resource value: 0x7f020000
 			public const int Icon = 2130837504;
-			
-			// aapt resource value: 0x7f020001
-			public const int notification_action_background = 2130837505;
-			
-			// aapt resource value: 0x7f020002
-			public const int notification_bg = 2130837506;
-			
-			// aapt resource value: 0x7f020003
-			public const int notification_bg_low = 2130837507;
-			
-			// aapt resource value: 0x7f020004
-			public const int notification_bg_low_normal = 2130837508;
-			
-			// aapt resource value: 0x7f020005
-			public const int notification_bg_low_pressed = 2130837509;
-			
-			// aapt resource value: 0x7f020006
-			public const int notification_bg_normal = 2130837510;
-			
-			// aapt resource value: 0x7f020007
-			public const int notification_bg_normal_pressed = 2130837511;
-			
-			// aapt resource value: 0x7f020008
-			public const int notification_icon_background = 2130837512;
-			
-			// aapt resource value: 0x7f02000b
-			public const int notification_template_icon_bg = 2130837515;
-			
-			// aapt resource value: 0x7f02000c
-			public const int notification_template_icon_low_bg = 2130837516;
-			
-			// aapt resource value: 0x7f020009
-			public const int notification_tile_bg = 2130837513;
-			
-			// aapt resource value: 0x7f02000a
-			public const int notify_panel_notification_icon_bg = 2130837514;
 			
 			static Drawable()
 			{
@@ -259,137 +82,59 @@ namespace XPlat.UnitTests.Android
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f09001b
-			public const int OptionHostName = 2131296283;
+			// aapt resource value: 0x7f050001
+			public const int OptionHostName = 2131034113;
 			
-			// aapt resource value: 0x7f09001c
-			public const int OptionPort = 2131296284;
+			// aapt resource value: 0x7f050002
+			public const int OptionPort = 2131034114;
 			
-			// aapt resource value: 0x7f09001a
-			public const int OptionRemoteServer = 2131296282;
+			// aapt resource value: 0x7f050000
+			public const int OptionRemoteServer = 2131034112;
 			
-			// aapt resource value: 0x7f09002a
-			public const int OptionsButton = 2131296298;
+			// aapt resource value: 0x7f050010
+			public const int OptionsButton = 2131034128;
 			
-			// aapt resource value: 0x7f090025
-			public const int ResultFullName = 2131296293;
+			// aapt resource value: 0x7f05000b
+			public const int ResultFullName = 2131034123;
 			
-			// aapt resource value: 0x7f090027
-			public const int ResultMessage = 2131296295;
+			// aapt resource value: 0x7f05000d
+			public const int ResultMessage = 2131034125;
 			
-			// aapt resource value: 0x7f090026
-			public const int ResultResultState = 2131296294;
+			// aapt resource value: 0x7f05000c
+			public const int ResultResultState = 2131034124;
 			
-			// aapt resource value: 0x7f090024
-			public const int ResultRunSingleMethodTest = 2131296292;
+			// aapt resource value: 0x7f05000a
+			public const int ResultRunSingleMethodTest = 2131034122;
 			
-			// aapt resource value: 0x7f090028
-			public const int ResultStackTrace = 2131296296;
+			// aapt resource value: 0x7f05000e
+			public const int ResultStackTrace = 2131034126;
 			
-			// aapt resource value: 0x7f090020
-			public const int ResultsFailed = 2131296288;
+			// aapt resource value: 0x7f050006
+			public const int ResultsFailed = 2131034118;
 			
-			// aapt resource value: 0x7f09001d
-			public const int ResultsId = 2131296285;
+			// aapt resource value: 0x7f050003
+			public const int ResultsId = 2131034115;
 			
-			// aapt resource value: 0x7f090021
-			public const int ResultsIgnored = 2131296289;
+			// aapt resource value: 0x7f050007
+			public const int ResultsIgnored = 2131034119;
 			
-			// aapt resource value: 0x7f090022
-			public const int ResultsInconclusive = 2131296290;
+			// aapt resource value: 0x7f050008
+			public const int ResultsInconclusive = 2131034120;
 			
-			// aapt resource value: 0x7f090023
-			public const int ResultsMessage = 2131296291;
+			// aapt resource value: 0x7f050009
+			public const int ResultsMessage = 2131034121;
 			
-			// aapt resource value: 0x7f09001f
-			public const int ResultsPassed = 2131296287;
+			// aapt resource value: 0x7f050005
+			public const int ResultsPassed = 2131034117;
 			
-			// aapt resource value: 0x7f09001e
-			public const int ResultsResult = 2131296286;
+			// aapt resource value: 0x7f050004
+			public const int ResultsResult = 2131034116;
 			
-			// aapt resource value: 0x7f090029
-			public const int RunTestsButton = 2131296297;
+			// aapt resource value: 0x7f05000f
+			public const int RunTestsButton = 2131034127;
 			
-			// aapt resource value: 0x7f09002b
-			public const int TestSuiteListView = 2131296299;
-			
-			// aapt resource value: 0x7f09000b
-			public const int action_container = 2131296267;
-			
-			// aapt resource value: 0x7f090017
-			public const int action_divider = 2131296279;
-			
-			// aapt resource value: 0x7f09000c
-			public const int action_image = 2131296268;
-			
-			// aapt resource value: 0x7f09000d
-			public const int action_text = 2131296269;
-			
-			// aapt resource value: 0x7f090018
-			public const int actions = 2131296280;
-			
-			// aapt resource value: 0x7f090006
-			public const int async = 2131296262;
-			
-			// aapt resource value: 0x7f090007
-			public const int blocking = 2131296263;
-			
-			// aapt resource value: 0x7f090016
-			public const int chronometer = 2131296278;
-			
-			// aapt resource value: 0x7f090008
-			public const int forever = 2131296264;
-			
-			// aapt resource value: 0x7f09000f
-			public const int icon = 2131296271;
-			
-			// aapt resource value: 0x7f090019
-			public const int icon_group = 2131296281;
-			
-			// aapt resource value: 0x7f090012
-			public const int info = 2131296274;
-			
-			// aapt resource value: 0x7f090009
-			public const int italic = 2131296265;
-			
-			// aapt resource value: 0x7f090000
-			public const int line1 = 2131296256;
-			
-			// aapt resource value: 0x7f090001
-			public const int line3 = 2131296257;
-			
-			// aapt resource value: 0x7f09000a
-			public const int normal = 2131296266;
-			
-			// aapt resource value: 0x7f090014
-			public const int notification_background = 2131296276;
-			
-			// aapt resource value: 0x7f090010
-			public const int notification_main_column = 2131296272;
-			
-			// aapt resource value: 0x7f09000e
-			public const int notification_main_column_container = 2131296270;
-			
-			// aapt resource value: 0x7f090013
-			public const int right_icon = 2131296275;
-			
-			// aapt resource value: 0x7f090011
-			public const int right_side = 2131296273;
-			
-			// aapt resource value: 0x7f090002
-			public const int tag_transition_group = 2131296258;
-			
-			// aapt resource value: 0x7f090003
-			public const int text = 2131296259;
-			
-			// aapt resource value: 0x7f090004
-			public const int text2 = 2131296260;
-			
-			// aapt resource value: 0x7f090015
-			public const int time = 2131296277;
-			
-			// aapt resource value: 0x7f090005
-			public const int title = 2131296261;
+			// aapt resource value: 0x7f050011
+			public const int TestSuiteListView = 2131034129;
 			
 			static Id()
 			{
@@ -401,54 +146,20 @@ namespace XPlat.UnitTests.Android
 			}
 		}
 		
-		public partial class Integer
-		{
-			
-			// aapt resource value: 0x7f0a0000
-			public const int status_bar_notification_info_maxnum = 2131361792;
-			
-			static Integer()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Integer()
-			{
-			}
-		}
-		
 		public partial class Layout
 		{
 			
 			// aapt resource value: 0x7f030000
-			public const int notification_action = 2130903040;
+			public const int options = 2130903040;
 			
 			// aapt resource value: 0x7f030001
-			public const int notification_action_tombstone = 2130903041;
+			public const int results = 2130903041;
 			
 			// aapt resource value: 0x7f030002
-			public const int notification_template_custom_big = 2130903042;
+			public const int test_result = 2130903042;
 			
 			// aapt resource value: 0x7f030003
-			public const int notification_template_icon_group = 2130903043;
-			
-			// aapt resource value: 0x7f030004
-			public const int notification_template_part_chronometer = 2130903044;
-			
-			// aapt resource value: 0x7f030005
-			public const int notification_template_part_time = 2130903045;
-			
-			// aapt resource value: 0x7f030006
-			public const int options = 2130903046;
-			
-			// aapt resource value: 0x7f030007
-			public const int results = 2130903047;
-			
-			// aapt resource value: 0x7f030008
-			public const int test_result = 2130903048;
-			
-			// aapt resource value: 0x7f030009
-			public const int test_suite = 2130903049;
+			public const int test_suite = 2130903043;
 			
 			static Layout()
 			{
@@ -463,14 +174,11 @@ namespace XPlat.UnitTests.Android
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f040002
-			public const int ApplicationName = 2130968578;
-			
 			// aapt resource value: 0x7f040001
-			public const int Hello = 2130968577;
+			public const int ApplicationName = 2130968577;
 			
 			// aapt resource value: 0x7f040000
-			public const int status_bar_notification_info_overflow = 2130968576;
+			public const int Hello = 2130968576;
 			
 			static String()
 			{
@@ -478,105 +186,6 @@ namespace XPlat.UnitTests.Android
 			}
 			
 			private String()
-			{
-			}
-		}
-		
-		public partial class Style
-		{
-			
-			// aapt resource value: 0x7f080000
-			public const int TextAppearance_Compat_Notification = 2131230720;
-			
-			// aapt resource value: 0x7f080001
-			public const int TextAppearance_Compat_Notification_Info = 2131230721;
-			
-			// aapt resource value: 0x7f080006
-			public const int TextAppearance_Compat_Notification_Line2 = 2131230726;
-			
-			// aapt resource value: 0x7f080002
-			public const int TextAppearance_Compat_Notification_Time = 2131230722;
-			
-			// aapt resource value: 0x7f080003
-			public const int TextAppearance_Compat_Notification_Title = 2131230723;
-			
-			// aapt resource value: 0x7f080004
-			public const int Widget_Compat_NotificationActionContainer = 2131230724;
-			
-			// aapt resource value: 0x7f080005
-			public const int Widget_Compat_NotificationActionText = 2131230725;
-			
-			static Style()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Style()
-			{
-			}
-		}
-		
-		public partial class Styleable
-		{
-			
-			public static int[] FontFamily = new int[] {
-					2130771968,
-					2130771969,
-					2130771970,
-					2130771971,
-					2130771972,
-					2130771973};
-			
-			// aapt resource value: 0
-			public const int FontFamily_fontProviderAuthority = 0;
-			
-			// aapt resource value: 3
-			public const int FontFamily_fontProviderCerts = 3;
-			
-			// aapt resource value: 4
-			public const int FontFamily_fontProviderFetchStrategy = 4;
-			
-			// aapt resource value: 5
-			public const int FontFamily_fontProviderFetchTimeout = 5;
-			
-			// aapt resource value: 1
-			public const int FontFamily_fontProviderPackage = 1;
-			
-			// aapt resource value: 2
-			public const int FontFamily_fontProviderQuery = 2;
-			
-			public static int[] FontFamilyFont = new int[] {
-					16844082,
-					16844083,
-					16844095,
-					2130771974,
-					2130771975,
-					2130771976};
-			
-			// aapt resource value: 0
-			public const int FontFamilyFont_android_font = 0;
-			
-			// aapt resource value: 2
-			public const int FontFamilyFont_android_fontStyle = 2;
-			
-			// aapt resource value: 1
-			public const int FontFamilyFont_android_fontWeight = 1;
-			
-			// aapt resource value: 4
-			public const int FontFamilyFont_font = 4;
-			
-			// aapt resource value: 3
-			public const int FontFamilyFont_fontStyle = 3;
-			
-			// aapt resource value: 5
-			public const int FontFamilyFont_fontWeight = 5;
-			
-			static Styleable()
-			{
-				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
-			}
-			
-			private Styleable()
 			{
 			}
 		}

--- a/XPlat.sln
+++ b/XPlat.sln
@@ -51,7 +51,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XPlat.Samples.iOS", "XPlat.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.ApplicationModel", "XPlat.ApplicationModel\XPlat.ApplicationModel.csproj", "{08E1FD7A-DB1F-416B-AFF8-1ACEC7525419}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XPlat.UI.Controls", "XPlat.UI.Controls\XPlat.UI.Controls.csproj", "{1D3C1D3A-4C5A-4D65-A453-4CFE4F3AA3B6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XPlat.UI.Controls", "XPlat.UI.Controls\XPlat.UI.Controls.csproj", "{1D3C1D3A-4C5A-4D65-A453-4CFE4F3AA3B6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -823,6 +823,8 @@ Global
 		{9A5B48A7-4615-4D21-B550-51F882B5AE26}.AppStore|x86.Build.0 = Release|Any CPU
 		{9A5B48A7-4615-4D21-B550-51F882B5AE26}.AppStore|x86.Deploy.0 = Release|Any CPU
 		{9A5B48A7-4615-4D21-B550-51F882B5AE26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A5B48A7-4615-4D21-B550-51F882B5AE26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A5B48A7-4615-4D21-B550-51F882B5AE26}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{9A5B48A7-4615-4D21-B550-51F882B5AE26}.Debug|ARM.ActiveCfg = Debug|Any CPU
 		{9A5B48A7-4615-4D21-B550-51F882B5AE26}.Debug|ARM.Build.0 = Debug|Any CPU
 		{9A5B48A7-4615-4D21-B550-51F882B5AE26}.Debug|ARM.Deploy.0 = Debug|Any CPU


### PR DESCRIPTION
## What kind of change does this PR introduce?
> Please check one or more that apply to this PR

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build or CI related changes
- [ ] Other (include details)

## What is the current behaviour?
> Please describe the current behaviour that you are modifying

When you try to add a file from cloud services, upon returning to the app from file picker, the file hasn't been retrieved.

## What is the new behaviour?
> Please describe the new behaviour that you have created

I have changed the way the FileOpenPicker works for android to use ActionOpenDocument rather than ActionGetContent, as this now uses the Android Documents Provider to retrieve the files and allows for use with cloud services such as Google Drive.

## What platforms does this change affect?
> Please check one or more that apply for this PR

- [ ] Windows (UWP)
- [x] Xamarin.Android
- [ ] Xamarin.iOS
- [ ] Xamarin.Forms

## PR checklist
> Please check if your PR fulfils the following requirements:

- [ ] Tests have been added (where applicable)
- [x] Code styling has been run on all new source file changes
- [x] Contains **NO** breaking changes

> If this PR contains a breaking change, please describe the impact and migration path below. Please note that breaking changes are likely to be rejected
