### PR TITLE
Updated Android components to support the use of the Application context

### DIFF
--- a/XPlat.Devices.Geolocation/Geolocator.Android.cs
+++ b/XPlat.Devices.Geolocation/Geolocator.Android.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__
+#if __ANDROID__
 namespace XPlat.Device.Geolocation
 {
     using System;
@@ -29,6 +29,13 @@ namespace XPlat.Device.Geolocation
         private uint reportInterval = 1;
 
         private PositionAccuracy desiredAccuracy;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Geolocator"/> class using the default <see cref="Android.App.Application.Context"/>.
+        /// </summary>
+        public Geolocator() : this(Android.App.Application.Context)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Geolocator"/> class.

--- a/XPlat.Devices.Launcher/Launcher.Android.cs
+++ b/XPlat.Devices.Launcher/Launcher.Android.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__
+#if __ANDROID__
 namespace XPlat.Device
 {
     using System;
@@ -12,9 +12,9 @@ namespace XPlat.Device
     public class Launcher : ILauncher
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Launcher"/> class.
+        /// Initializes a new instance of the <see cref="Launcher"/> class using the default <see cref="Android.App.Application.Context"/>.
         /// </summary>
-        public Launcher()
+        public Launcher() : this(Android.App.Application.Context)
         {
         }
 

--- a/XPlat.Media.Capture/CameraCaptureUI.Android.cs
+++ b/XPlat.Media.Capture/CameraCaptureUI.Android.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__
+#if __ANDROID__
 namespace XPlat.Media.Capture
 {
     using System;
@@ -18,13 +18,18 @@ namespace XPlat.Media.Capture
     /// <summary>Provides a full window UI for capturing video and photos from a camera.</summary>
     public class CameraCaptureUI : ICameraCaptureUI
     {
-        private readonly Context context;
-
         private int requestId;
 
         private TaskCompletionSource<IStorageFile> currentSingleTcs;
 
         private int requestCode;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CameraCaptureUI"/> class using the default <see cref="Android.App.Application.Context"/>.
+        /// </summary>
+        public CameraCaptureUI() : this(Android.App.Application.Context)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CameraCaptureUI"/> class.
@@ -34,10 +39,13 @@ namespace XPlat.Media.Capture
         /// </param>
         public CameraCaptureUI(Context context)
         {
-            this.context = context;
+            this.Context = context;
             this.PhotoSettings = new CameraCaptureUIPhotoCaptureSettings();
             this.VideoSettings = new CameraCaptureUIVideoCaptureSettings();
         }
+
+        /// <summary>Gets or sets the Android context to be used for handling activity and intent events.</summary>
+        public Context Context { get; set; }
 
         /// <summary>Provides settings for capturing photos.</summary>
         public CameraCaptureUIPhotoCaptureSettings PhotoSettings { get; }
@@ -60,7 +68,7 @@ namespace XPlat.Media.Capture
 
             this.requestCode = newRequestCode;
 
-            this.context.StartActivity(this.GenerateIntent(this.requestCode, mode));
+            this.Context.StartActivity(this.GenerateIntent(this.requestCode, mode));
 
             TypedEventHandler<Activity, CameraFileCaptured> handler = null;
             handler = async (sender, args) =>
@@ -115,7 +123,7 @@ namespace XPlat.Media.Capture
 
         private Intent GenerateIntent(int id, CameraCaptureUIMode mode)
         {
-            Intent cameraCaptureIntent = new Intent(this.context, typeof(CameraCaptureUIActivity));
+            Intent cameraCaptureIntent = new Intent(this.Context, typeof(CameraCaptureUIActivity));
             cameraCaptureIntent.PutExtra(CameraCaptureUIActivity.IntentId, id);
 
             switch (mode)

--- a/XPlat.Storage.Pickers/FileOpenPicker.Android.cs
+++ b/XPlat.Storage.Pickers/FileOpenPicker.Android.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__
+#if __ANDROID__
 namespace XPlat.Storage.Pickers
 {
     using System;
@@ -15,13 +15,18 @@ namespace XPlat.Storage.Pickers
     /// <summary>Represents a UI element that lets the user choose and open files.</summary>
     public class FileOpenPicker : IFileOpenPicker
     {
-        private readonly Context context;
-
         private TaskCompletionSource<IStorageFile> currentSingleTcs;
 
         private TaskCompletionSource<IReadOnlyList<IStorageFile>> currentMultiTcs;
 
         private int requestCode;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileOpenPicker"/> class using the default <see cref="Android.App.Application.Context"/>.
+        /// </summary>
+        public FileOpenPicker() : this(Android.App.Application.Context)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileOpenPicker"/> class.
@@ -31,9 +36,12 @@ namespace XPlat.Storage.Pickers
         /// </param>
         public FileOpenPicker(Context context)
         {
-            this.context = context;
+            this.Context = context;
             this.FileTypeFilter = new List<string>();
         }
+
+        /// <summary>Gets or sets the Android context to be used for handling activity and intent events.</summary>
+        public Context Context { get; set; }
 
         /// <summary>Gets the collection of file types that the file open picker displays.</summary>
         public IList<string> FileTypeFilter { get; }
@@ -52,7 +60,7 @@ namespace XPlat.Storage.Pickers
 
             this.requestCode = newRequestCode;
 
-            this.context.StartActivity(this.GenerateIntent(this.requestCode, false));
+            this.Context.StartActivity(this.GenerateIntent(this.requestCode, false));
 
             TypedEventHandler<Activity, FileOpenPickerFilesReceived> handler = null;
             handler = (sender, args) =>
@@ -89,7 +97,7 @@ namespace XPlat.Storage.Pickers
 
             this.requestCode = newRequestCode;
 
-            this.context.StartActivity(this.GenerateIntent(this.requestCode, true));
+            this.Context.StartActivity(this.GenerateIntent(this.requestCode, true));
 
             TypedEventHandler<Activity, FileOpenPickerFilesReceived> handler = null;
             handler = (sender, args) =>
@@ -122,7 +130,7 @@ namespace XPlat.Storage.Pickers
 
         private Intent GenerateIntent(int id, bool allowMultiple)
         {
-            Intent fileOpenPickerIntent = new Intent(this.context, typeof(FileOpenPickerActivity));
+            Intent fileOpenPickerIntent = new Intent(this.Context, typeof(FileOpenPickerActivity));
             fileOpenPickerIntent.PutExtra(FileOpenPickerActivity.IntentId, id);
 
             IEnumerable<string> mimeTypes = MimeTypeHelper.GetMimeTypes(this.FileTypeFilter);

--- a/XPlat.UI.Popups/MessageDialog.Android.cs
+++ b/XPlat.UI.Popups/MessageDialog.Android.cs
@@ -1,4 +1,4 @@
-﻿#if __ANDROID__
+#if __ANDROID__
 namespace XPlat.UI.Popups
 {
     using System;
@@ -13,20 +13,34 @@ namespace XPlat.UI.Popups
     {
         /// <summary>Initializes a new instance of the MessageDialog class to display an untitled message dialog that can be used to ask your user simple questions.</summary>
         /// <param name="content">The message displayed to the user.</param>
-        public MessageDialog(string content)
+        public MessageDialog(string content) : this(content, string.Empty, Android.App.Application.Context)
         {
-            this.Content = content;
-            this.Commands = new List<IUICommand>();
+        }
+
+        /// <summary>Initializes a new instance of the MessageDialog class to display an untitled message dialog that can be used to ask your user simple questions.</summary>
+        /// <param name="content">The message displayed to the user.</param>
+        /// <param name="context">The Android context.</param>
+        public MessageDialog(string content, Android.Content.Context context) : this(content, string.Empty, context)
+        {
         }
 
         /// <summary>Initializes a new instance of the MessageDialog class to display a titled message dialog that can be used to ask your user simple questions.</summary>
         /// <param name="content">The message displayed to the user.</param>
         /// <param name="title">The title you want displayed on the dialog.</param>
-        public MessageDialog(string content, string title)
+        public MessageDialog(string content, string title) : this(content, title, Android.App.Application.Context)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the MessageDialog class to display a titled message dialog that can be used to ask your user simple questions.</summary>
+        /// <param name="content">The message displayed to the user.</param>
+        /// <param name="title">The title you want displayed on the dialog.</param>
+        /// <param name="context">The Android context.</param>
+        public MessageDialog(string content, string title, Android.Content.Context context)
         {
             this.Content = content;
             this.Title = title;
             this.Commands = new List<IUICommand>();
+            this.Context = context;
         }
 
         /// <summary>


### PR DESCRIPTION
## PR summary
<!-- Please provide a description below of the changes made and how it was tested -->

Changes have been made to the Android components which support the use of an Android context to support default constructors for using the default Android application context. This will resolve issue #73 

In addition to these changes, updates have been made to make read-only context fields a public accessible property so that it can be set outside of the constructor to help with code re-use.

## Areas affected
> Please check one or more that apply

- [ ] UWP
- [x] Android
- [ ] iOS
- [ ] CI/CD

## PR checklist

- [ ] Tests have been added/updated and pass
- [x] Code styling has been run on all new source file changes
- [ ] Wiki documentation has been added
- [ ] Code sample has been added
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

No breaking changes made.

## References
<!-- Please provide any additional references below that are relevant to the changes made (i.e. another work item, existing PR) -->

No additional references.